### PR TITLE
🔧 Refine: Input Sanitization and Trimming

### DIFF
--- a/src/components/ContributeForm.jsx
+++ b/src/components/ContributeForm.jsx
@@ -7,6 +7,7 @@ import {
 } from 'obscenity';
 import { saveQuestion } from '../services/dataService';
 import { useToast } from './ToastMessage/Toast';
+import { sanitizeInput } from '../utils/sanitization';
 import useBibleReference from '../hooks/useBibleReference';
 
 import Button from './ui/Button';
@@ -76,7 +77,7 @@ const ContributeForm = () => {
         try {
             const saved = await saveQuestion(
                 selectedTheme,
-                questionText,
+                sanitizeInput(questionText),
                 {
                     book,
                     chapter,

--- a/src/components/EditQuestionModal.jsx
+++ b/src/components/EditQuestionModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X } from 'lucide-react';
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
+import { sanitizeInput } from '../utils/sanitization';
 import useBibleReference from '../hooks/useBibleReference';
 import BibleReferenceSelector from './BibleReferenceSelector';
 import ThemeSelect from './ui/ThemeSelect';
@@ -34,7 +35,7 @@ const EditQuestionModal = ({ isOpen, onClose, question, onSave }) => {
                 verseStart,
                 verseEnd: verseEnd || verseStart,
                 theme: selectedTheme,
-                question: questionText,
+                question: sanitizeInput(questionText),
             });
             onClose();
         } catch (error) {

--- a/src/utils/sanitization.js
+++ b/src/utils/sanitization.js
@@ -22,11 +22,12 @@ export const standardizeSymbols = (text) => {
 export const sanitizeInput = (input) => {
   if (typeof input !== 'string') return input;
   const standardized = standardizeSymbols(input);
-  return filterXSS(standardized, {
+  const filtered = filterXSS(standardized, {
     whiteList: {}, // No HTML tags allowed
     stripIgnoreTag: true, // Remove all HTML tags
     stripIgnoreTagBody: ['script'], // Remove script tags and their content
   });
+  return filtered.trim();
 };
 
 const defaultExport = {


### PR DESCRIPTION
I have refined the input handling for Bible study questions. 

**Changes:**
1.  **Utility Update:** Modified `src/utils/sanitization.js` to include a `.trim()` step in the `sanitizeInput` function. This prevents leading/trailing whitespace from being saved to the database.
2.  **Form Enhancement:** Applied `sanitizeInput` to the question text in `src/components/ContributeForm.jsx`. Previously, question text was saved without sanitization.
3.  **Modal Enhancement:** Applied `sanitizeInput` to the question text in `src/components/EditQuestionModal.jsx`. 

**Impact:**
- **Data Quality:** Eliminates inconsistent whitespace in stored questions.
- **Security:** Enhances protection against Cross-Site Scripting (XSS) by ensuring that all user-contributed and edited question text is filtered through the existing XSS utility before persistence.
- **Consistency:** Aligns the handling of question text with the already-sanitized Bible references.

---
*PR created automatically by Jules for task [13706466875966295985](https://jules.google.com/task/13706466875966295985) started by @allemandi*