### PR TITLE
🔧 Refine: performance and accessibility improvements

### DIFF
--- a/src/components/ContributeForm.jsx
+++ b/src/components/ContributeForm.jsx
@@ -18,6 +18,11 @@ import Textarea from './ui/Textarea';
 import BibleReferenceSelector from './BibleReferenceSelector';
 import LoadingOverlay from './ui/LoadingOverlay';
 
+const matcher = new RegExpMatcher({
+    ...englishDataset.build(),
+    ...englishRecommendedTransformers,
+});
+
 const ContributeForm = () => {
     const showToast = useToast();
     const [questionText, setQuestionText] = useState('');
@@ -40,11 +45,6 @@ const ContributeForm = () => {
     useEffect(() => {
         if (verseStart && errors.verseStart) setErrors(prev => ({ ...prev, verseStart: null }));
     }, [verseStart, errors.verseStart]);
-
-    const matcher = new RegExpMatcher({
-        ...englishDataset.build(),
-        ...englishRecommendedTransformers,
-    });
 
     const validate = () => {
         const newErrors = {};

--- a/src/components/RequestForm.jsx
+++ b/src/components/RequestForm.jsx
@@ -308,7 +308,7 @@ const RequestForm = ({ onStudyGenerated, isLoading, setTabValue }) => {
                     <div className="flex justify-center pt-8 border-t-2 border-app-border">
                         {isGenerateDisabled ? (
                             <Tooltip content="Select at least one question from search results">
-                                <Button type="button" disabled variant="outline" className="flex-grow max-w-xs opacity-50 cursor-not-allowed">
+                                <Button type="button" aria-disabled="true" variant="outline" className="flex-grow max-w-xs opacity-50 cursor-not-allowed">
                                     <BookOpen size={18} />
                                     Generate Study
                                 </Button>

--- a/src/components/Tooltip.jsx
+++ b/src/components/Tooltip.jsx
@@ -55,7 +55,20 @@ const Tooltip = ({ content, children }) => {
     return false;
   };
 
+  const checkDisabledChild = (element) => {
+    if (!element || !React.isValidElement(element)) return false;
+    const props = element.props || {};
+    if (props.disabled || props['aria-disabled'] === true || props['aria-disabled'] === 'true') {
+      return true;
+    }
+    if (props.children) {
+      return React.Children.toArray(props.children).some(checkDisabledChild);
+    }
+    return false;
+  };
+
   const hasInteractiveChild = React.Children.toArray(children).some(isInteractive);
+  const hasDisabledChild = React.Children.toArray(children).some(checkDisabledChild);
 
   return (
     <span
@@ -65,7 +78,7 @@ const Tooltip = ({ content, children }) => {
       onFocusCapture={showTip}
       onBlurCapture={hideTip}
       onKeyDown={handleKeyDown}
-      tabIndex={hasInteractiveChild ? -1 : 0}
+      tabIndex={hasDisabledChild ? 0 : (hasInteractiveChild ? -1 : 0)}
       aria-describedby={visible ? "tooltip" : undefined}
     >
       {children}


### PR DESCRIPTION
**What:**
- Optimized `ContributeForm` by moving `RegExpMatcher` instantiation outside the component.
- Enhanced `Tooltip` component to be keyboard-accessible when wrapping disabled elements by making the wrapper focusable (`tabIndex={0}`) when a disabled child is detected.
- Switched the "Generate Study" button in `RequestForm` to use `aria-disabled` instead of `disabled`.

**Why:**
- `RegExpMatcher` (from the `obscenity` library) was being recreated on every render in `ContributeForm`, causing unnecessary performance overhead for a static configuration.
- Standard `disabled` buttons cannot be focused by keyboard users, preventing them from viewing tooltips that explain why an action (like "Generate Study") is unavailable.

**Impact:**
- Smoother form interactions in the Contribute section.
- Improved accessibility for keyboard and screen reader users, ensuring they can perceive and understand the state of inactive interactive elements.

---
*PR created automatically by Jules for task [7600719318593605482](https://jules.google.com/task/7600719318593605482) started by @allemandi*