### PR TITLE
Update MongoDB URI examples to Atlas format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # MongoDB Connection
-MONGODB_URI=mongodb://localhost:27017/passage-prep
+MONGODB_URI=mongodb+srv://YOUR_USERNAME:YOUR_PASSWORD@YOUR_CLUSTER.mongodb.net/?retryWrites=true&w=majority
 
 # Admin Credentials (for setup-admin script)
 ADMINUSER=admin

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 2. **Configure MongoDB:**
    - Create `.env` in the root:
      ```
-     MONGODB_URI=<your_mongodb_connection_string>
+     MONGODB_URI=mongodb+srv://YOUR_USERNAME:YOUR_PASSWORD@YOUR_CLUSTER.mongodb.net/?retryWrites=true&w=majority
      ```
 3. **Import Data:**
    - Preload sample questions:


### PR DESCRIPTION
I have updated the MongoDB URI examples in `.env.example` and `README.md` to use the more modern MongoDB Atlas connection string format as requested.

Changes:
- In `.env.example`: Replaced `mongodb://localhost:27017/passage-prep` with `mongodb+srv://YOUR_USERNAME:YOUR_PASSWORD@YOUR_CLUSTER.mongodb.net/?retryWrites=true&w=majority`.
- In `README.md`: Replaced `MONGODB_URI=<your_mongodb_connection_string>` with `MONGODB_URI=mongodb+srv://YOUR_USERNAME:YOUR_PASSWORD@YOUR_CLUSTER.mongodb.net/?retryWrites=true&w=majority`.

I verified that no other occurrences of the old connection string format existed in the codebase and ran the existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [7300510872509742913](https://jules.google.com/task/7300510872509742913) started by @allemandi*